### PR TITLE
Configure JWT options and key

### DIFF
--- a/BookLibwithSub.API/Controllers/AuthController.cs
+++ b/BookLibwithSub.API/Controllers/AuthController.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading.Tasks;
+using BookLibwithSub.Service.Interfaces;
+using BookLibwithSub.Service.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BookLibwithSub.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AuthController : ControllerBase
+    {
+        private readonly IAuthService _authService;
+
+        public AuthController(IAuthService authService)
+        {
+            _authService = authService;
+        }
+
+        [HttpPost("register")]
+        [AllowAnonymous]
+        public async Task<IActionResult> Register([FromBody] RegisterRequest request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                await _authService.RegisterAsync(request);
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+        }
+
+        [HttpPost("login")]
+        [AllowAnonymous]
+        public async Task<IActionResult> Login([FromBody] LoginRequest request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var token = await _authService.LoginAsync(request);
+            if (token == null)
+            {
+                return Unauthorized();
+            }
+
+            return Ok(new { token });
+        }
+    }
+}

--- a/BookLibwithSub.API/Controllers/SubscriptionPlansController.cs
+++ b/BookLibwithSub.API/Controllers/SubscriptionPlansController.cs
@@ -1,0 +1,52 @@
+using BookLibwithSub.Repo.Entities;
+using BookLibwithSub.Service.Interfaces;
+using BookLibwithSub.Service.Constants;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BookLibwithSub.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class SubscriptionPlansController : ControllerBase
+    {
+        private readonly ISubscriptionPlanService _service;
+        public SubscriptionPlansController(ISubscriptionPlanService service)
+        {
+            _service = service;
+        }
+
+        [HttpPost]
+        [Authorize(Roles = Roles.Admin)]
+        public async Task<IActionResult> Create(SubscriptionPlan plan)
+        {
+            var created = await _service.AddAsync(plan);
+            return CreatedAtAction(nameof(Get), new { id = created.SubscriptionPlanID }, created);
+        }
+
+        [HttpGet("{id}")]
+        [Authorize]
+        public async Task<IActionResult> Get(int id)
+        {
+            var plan = await _service.GetByIdAsync(id);
+            if (plan == null) return NotFound();
+            return Ok(plan);
+        }
+
+        [HttpPut("{id}")]
+        [Authorize(Roles = Roles.Admin)]
+        public async Task<IActionResult> Update(int id, SubscriptionPlan plan)
+        {
+            await _service.UpdateAsync(id, plan);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        [Authorize(Roles = Roles.Admin)]
+        public async Task<IActionResult> Delete(int id)
+        {
+            await _service.DeleteAsync(id);
+            return NoContent();
+        }
+    }
+}

--- a/BookLibwithSub.API/appsettings.json
+++ b/BookLibwithSub.API/appsettings.json
@@ -11,7 +11,7 @@
     "AllowedOrigins": [ "http://localhost:5173", "https://your-frontend.example.com" ]
   },
   "Jwt": {
-    "Key": "j6LQbQkD7P2Yt7wY1lFrUgjK5a3uXn9B0+f6gJNzjJg4sQmU8+1Z3n2T5cXoU9vW2qXz4nH7bP8rYfK3qLmN2x5c8v9tJ0rY",
+    "Key": "os2DQnqoXmgmdnFOvpXLfhxJm3Biof3DqVuQ35u42tHp1YqPZ3n9qypgI1G1sD4C8k5UcS7w0USBrxeBkqCK_w==",
     "Issuer": "BookLibIssuer"
   },
   "AllowedHosts": "*"

--- a/BookLibwithSub.Repo/Interfaces/ILoanRepository.cs
+++ b/BookLibwithSub.Repo/Interfaces/ILoanRepository.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+
+namespace BookLibwithSub.Repo.Interfaces
+{
+    public interface ILoanRepository
+    {
+        Task<int> CountLoanItemsAsync(int subscriptionId, DateTime start, DateTime end);
+        Task AddAsync(Loan loan);
+        Task ReturnAsync(int loanItemId);
+    }
+}

--- a/BookLibwithSub.Repo/Interfaces/ISubscriptionPlanRepository.cs
+++ b/BookLibwithSub.Repo/Interfaces/ISubscriptionPlanRepository.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+
+namespace BookLibwithSub.Repo.Interfaces
+{
+    public interface ISubscriptionPlanRepository
+    {
+        Task<SubscriptionPlan?> GetByIdAsync(int id);
+        Task AddAsync(SubscriptionPlan plan);
+        Task UpdateAsync(SubscriptionPlan plan);
+        Task DeleteAsync(int id);
+    }
+}

--- a/BookLibwithSub.Repo/Interfaces/ISubscriptionRepository.cs
+++ b/BookLibwithSub.Repo/Interfaces/ISubscriptionRepository.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+
+namespace BookLibwithSub.Repo.Interfaces
+{
+    public interface ISubscriptionRepository
+    {
+        Task<Subscription?> GetByIdWithPlanAsync(int id);
+    }
+}

--- a/BookLibwithSub.Repo/Interfaces/IUserRepository.cs
+++ b/BookLibwithSub.Repo/Interfaces/IUserRepository.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+
+namespace BookLibwithSub.Repo.Interfaces
+{
+    public interface IUserRepository
+    {
+        Task<User?> GetByUsernameAsync(string username);
+        Task<User?> GetByEmailAsync(string email);
+        Task AddAsync(User user);
+    }
+}

--- a/BookLibwithSub.Repo/LoanRepository.cs
+++ b/BookLibwithSub.Repo/LoanRepository.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+using BookLibwithSub.Repo.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookLibwithSub.Repo
+{
+    public class LoanRepository : ILoanRepository
+    {
+        private readonly AppDbContext _context;
+        public LoanRepository(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<int> CountLoanItemsAsync(int subscriptionId, DateTime start, DateTime end)
+        {
+            return await _context.LoanItems
+                .Where(li => li.Loan.SubscriptionID == subscriptionId &&
+                             li.Loan.LoanDate >= start && li.Loan.LoanDate < end)
+                .CountAsync();
+        }
+
+        public async Task AddAsync(Loan loan)
+        {
+            foreach (var item in loan.LoanItems)
+            {
+                var book = await _context.Books.FirstOrDefaultAsync(b => b.BookID == item.BookID);
+                if (book == null || book.AvailableCopies <= 0)
+                    throw new InvalidOperationException($"Book {item.BookID} not available");
+                book.AvailableCopies--;
+            }
+
+            _context.Loans.Add(loan);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task ReturnAsync(int loanItemId)
+        {
+            var item = await _context.LoanItems
+                .Include(li => li.Book)
+                .FirstOrDefaultAsync(li => li.LoanItemID == loanItemId);
+            if (item == null)
+                throw new InvalidOperationException("Loan item not found");
+            if (item.Status == "Returned")
+                return;
+
+            item.ReturnedDate = DateTime.UtcNow;
+            item.Status = "Returned";
+            item.Book.AvailableCopies++;
+
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/BookLibwithSub.Repo/SubscriptionPlanRepository.cs
+++ b/BookLibwithSub.Repo/SubscriptionPlanRepository.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+using BookLibwithSub.Repo.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookLibwithSub.Repo
+{
+    public class SubscriptionPlanRepository : ISubscriptionPlanRepository
+    {
+        private readonly AppDbContext _context;
+        public SubscriptionPlanRepository(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<SubscriptionPlan?> GetByIdAsync(int id)
+        {
+            return await _context.SubscriptionPlans.FindAsync(id);
+        }
+
+        public async Task AddAsync(SubscriptionPlan plan)
+        {
+            _context.SubscriptionPlans.Add(plan);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task UpdateAsync(SubscriptionPlan plan)
+        {
+            _context.SubscriptionPlans.Update(plan);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task DeleteAsync(int id)
+        {
+            var plan = await _context.SubscriptionPlans.FindAsync(id);
+            if (plan != null)
+            {
+                _context.SubscriptionPlans.Remove(plan);
+                await _context.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/BookLibwithSub.Repo/SubscriptionRepository.cs
+++ b/BookLibwithSub.Repo/SubscriptionRepository.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+using BookLibwithSub.Repo.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookLibwithSub.Repo
+{
+    public class SubscriptionRepository : ISubscriptionRepository
+    {
+        private readonly AppDbContext _context;
+        public SubscriptionRepository(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<Subscription?> GetByIdWithPlanAsync(int id)
+        {
+            return await _context.Subscriptions
+                .Include(s => s.SubscriptionPlan)
+                .FirstOrDefaultAsync(s => s.SubscriptionID == id);
+        }
+    }
+}

--- a/BookLibwithSub.Repo/UserRepository.cs
+++ b/BookLibwithSub.Repo/UserRepository.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+using BookLibwithSub.Repo.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookLibwithSub.Repo
+{
+    public class UserRepository : IUserRepository
+    {
+        private readonly AppDbContext _context;
+        public UserRepository(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<User?> GetByUsernameAsync(string username)
+        {
+            return await _context.Users.FirstOrDefaultAsync(u => u.Username == username);
+        }
+
+        public async Task<User?> GetByEmailAsync(string email)
+        {
+            return await _context.Users.FirstOrDefaultAsync(u => u.Email == email);
+        }
+
+        public async Task AddAsync(User user)
+        {
+            _context.Users.Add(user);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/BookLibwithSub.Service/AuthService.cs
+++ b/BookLibwithSub.Service/AuthService.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using BookLibwithSub.Repo.Entities;
+using BookLibwithSub.Repo.Interfaces;
+using BookLibwithSub.Service.Interfaces;
+using BookLibwithSub.Service.Models;
+using BookLibwithSub.Service.Constants;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace BookLibwithSub.Service
+{
+    public class AuthService : IAuthService
+    {
+        private readonly IUserRepository _userRepository;
+        private readonly JwtOptions _jwtOptions;
+
+        public AuthService(IUserRepository userRepository, IOptions<JwtOptions> jwtOptions)
+        {
+            _userRepository = userRepository;
+            _jwtOptions = jwtOptions.Value;
+        }
+
+        public async Task RegisterAsync(RegisterRequest request)
+        {
+            var existing = await _userRepository.GetByUsernameAsync(request.Username);
+            if (existing != null)
+            {
+                throw new InvalidOperationException("Username already exists");
+            }
+
+            var emailAttr = new System.ComponentModel.DataAnnotations.EmailAddressAttribute();
+            if (!emailAttr.IsValid(request.Email))
+            {
+                throw new InvalidOperationException("Invalid email format");
+            }
+
+            var existingEmail = await _userRepository.GetByEmailAsync(request.Email);
+            if (existingEmail != null)
+            {
+                throw new InvalidOperationException("Email already exists");
+            }
+
+            var user = new User
+            {
+                Username = request.Username,
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword(request.Password),
+                FullName = request.FullName,
+                Email = request.Email,
+                PhoneNumber = request.PhoneNumber,
+                Role = request.Role?.ToLower() == Roles.Admin ? Roles.Admin : Roles.User,
+                CreatedDate = DateTime.UtcNow
+            };
+
+            await _userRepository.AddAsync(user);
+        }
+
+        public async Task<string?> LoginAsync(LoginRequest request)
+        {
+            var user = await _userRepository.GetByUsernameAsync(request.Username);
+            if (user == null)
+                return null;
+
+            if (!BCrypt.Net.BCrypt.Verify(request.Password, user.PasswordHash))
+                return null;
+
+            var key = _jwtOptions.Key;
+            if (string.IsNullOrEmpty(key))
+                throw new InvalidOperationException("JWT key not configured");
+
+            var issuer = _jwtOptions.Issuer;
+
+            var claims = new[]
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, user.UserID.ToString()),
+                new Claim(ClaimTypes.Name, user.Username),
+                new Claim(ClaimTypes.Role, user.Role)
+            };
+
+            var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key));
+            var token = new JwtSecurityToken(
+                issuer: issuer,
+                audience: issuer,
+                claims: claims,
+                expires: DateTime.UtcNow.AddHours(1),
+                signingCredentials: new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256)
+            );
+
+            return new JwtSecurityTokenHandler().WriteToken(token);
+        }
+    }
+}

--- a/BookLibwithSub.Service/BookLibwithSub.Service.csproj
+++ b/BookLibwithSub.Service/BookLibwithSub.Service.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
   </ItemGroup>
 

--- a/BookLibwithSub.Service/Constants/Roles.cs
+++ b/BookLibwithSub.Service/Constants/Roles.cs
@@ -1,0 +1,8 @@
+namespace BookLibwithSub.Service.Constants
+{
+    public static class Roles
+    {
+        public const string Admin = "admin";
+        public const string User = "user";
+    }
+}

--- a/BookLibwithSub.Service/Interfaces/IAuthService.cs
+++ b/BookLibwithSub.Service/Interfaces/IAuthService.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using BookLibwithSub.Service.Models;
+
+namespace BookLibwithSub.Service.Interfaces
+{
+    public interface IAuthService
+    {
+        Task RegisterAsync(RegisterRequest request);
+        Task<string?> LoginAsync(LoginRequest request);
+    }
+}

--- a/BookLibwithSub.Service/Interfaces/ILoanService.cs
+++ b/BookLibwithSub.Service/Interfaces/ILoanService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace BookLibwithSub.Service.Interfaces
+{
+    public interface ILoanService
+    {
+        Task BorrowAsync(int subscriptionId, IEnumerable<int> bookIds);
+        Task ReturnAsync(int loanItemId);
+    }
+}

--- a/BookLibwithSub.Service/Interfaces/ISubscriptionPlanService.cs
+++ b/BookLibwithSub.Service/Interfaces/ISubscriptionPlanService.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+
+namespace BookLibwithSub.Service.Interfaces
+{
+    public interface ISubscriptionPlanService
+    {
+        Task<SubscriptionPlan> AddAsync(SubscriptionPlan plan);
+        Task<SubscriptionPlan?> GetByIdAsync(int id);
+        Task UpdateAsync(int id, SubscriptionPlan plan);
+        Task DeleteAsync(int id);
+    }
+}

--- a/BookLibwithSub.Service/LoanService.cs
+++ b/BookLibwithSub.Service/LoanService.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+using BookLibwithSub.Repo.Interfaces;
+using BookLibwithSub.Service.Interfaces;
+
+namespace BookLibwithSub.Service
+{
+    public class LoanService : ILoanService
+    {
+        private readonly ISubscriptionRepository _subscriptionRepo;
+        private readonly ILoanRepository _loanRepo;
+
+        public LoanService(ISubscriptionRepository subscriptionRepo, ILoanRepository loanRepo)
+        {
+            _subscriptionRepo = subscriptionRepo;
+            _loanRepo = loanRepo;
+        }
+
+        public async Task BorrowAsync(int subscriptionId, IEnumerable<int> bookIds)
+        {
+            var subscription = await _subscriptionRepo.GetByIdWithPlanAsync(subscriptionId);
+            if (subscription == null)
+                throw new InvalidOperationException("Subscription not found");
+
+            if (subscription.Status != "Active" ||
+                subscription.StartDate > DateTime.UtcNow ||
+                subscription.EndDate < DateTime.UtcNow)
+            {
+                throw new InvalidOperationException("Subscription is not active or out of date range");
+            }
+
+            var plan = subscription.SubscriptionPlan;
+            if (plan == null)
+                throw new InvalidOperationException("Subscription plan missing");
+
+            var now = DateTime.UtcNow;
+            var dayStart = now.Date;
+            var dayEnd = dayStart.AddDays(1);
+            var monthStart = new DateTime(now.Year, now.Month, 1);
+            var monthEnd = monthStart.AddMonths(1);
+
+            int alreadyToday = await _loanRepo.CountLoanItemsAsync(subscriptionId, dayStart, dayEnd);
+            int alreadyMonth = await _loanRepo.CountLoanItemsAsync(subscriptionId, monthStart, monthEnd);
+            int requested = bookIds.Count();
+
+            if (alreadyToday + requested > plan.MaxPerDay)
+                throw new InvalidOperationException("Daily borrowing limit exceeded");
+
+            if (alreadyMonth + requested > plan.MaxPerMonth)
+                throw new InvalidOperationException("Monthly borrowing limit exceeded");
+
+            var loan = new Loan
+            {
+                SubscriptionID = subscriptionId,
+                LoanDate = now,
+                Status = "Borrowed",
+                LoanItems = bookIds.Select(id => new LoanItem
+                {
+                    BookID = id,
+                    DueDate = now.AddDays(14),
+                    Status = "Borrowed"
+                }).ToList()
+            };
+
+            await _loanRepo.AddAsync(loan);
+        }
+
+        public async Task ReturnAsync(int loanItemId)
+        {
+            await _loanRepo.ReturnAsync(loanItemId);
+        }
+    }
+}

--- a/BookLibwithSub.Service/Models/JwtOptions.cs
+++ b/BookLibwithSub.Service/Models/JwtOptions.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace BookLibwithSub.Service.Models
+{
+    /// <summary>
+    /// Strongly typed settings for JWT token generation and validation.
+    /// Values are bound from configuration ("Jwt" section).
+    /// </summary>
+    public class JwtOptions
+    {
+        public string Key { get; set; } = string.Empty;
+        public string Issuer { get; set; } = string.Empty;
+    }
+}

--- a/BookLibwithSub.Service/Models/LoginRequest.cs
+++ b/BookLibwithSub.Service/Models/LoginRequest.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BookLibwithSub.Service.Models
+{
+    public class LoginRequest
+    {
+        [Required]
+        public string Username { get; set; } = string.Empty;
+
+        [Required]
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/BookLibwithSub.Service/Models/RegisterRequest.cs
+++ b/BookLibwithSub.Service/Models/RegisterRequest.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using BookLibwithSub.Service.Constants;
+
+namespace BookLibwithSub.Service.Models
+{
+    public class RegisterRequest
+    {
+        [Required]
+        public string Username { get; set; } = string.Empty;
+
+        [Required]
+        public string Password { get; set; } = string.Empty;
+
+        [Required]
+        public string FullName { get; set; } = string.Empty;
+
+        [Required, EmailAddress]
+        public string Email { get; set; } = string.Empty;
+
+        [Phone]
+        public string PhoneNumber { get; set; } = string.Empty;
+
+        public string Role { get; set; } = Roles.User;
+    }
+}

--- a/BookLibwithSub.Service/SubscriptionPlanService.cs
+++ b/BookLibwithSub.Service/SubscriptionPlanService.cs
@@ -1,0 +1,47 @@
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+using BookLibwithSub.Repo.Interfaces;
+using BookLibwithSub.Service.Interfaces;
+
+namespace BookLibwithSub.Service
+{
+    public class SubscriptionPlanService : ISubscriptionPlanService
+    {
+        private readonly ISubscriptionPlanRepository _repo;
+        public SubscriptionPlanService(ISubscriptionPlanRepository repo)
+        {
+            _repo = repo;
+        }
+
+        public async Task<SubscriptionPlan> AddAsync(SubscriptionPlan plan)
+        {
+            await _repo.AddAsync(plan);
+            return plan;
+        }
+
+        public Task<SubscriptionPlan?> GetByIdAsync(int id)
+        {
+            return _repo.GetByIdAsync(id);
+        }
+
+        public async Task UpdateAsync(int id, SubscriptionPlan plan)
+        {
+            var existing = await _repo.GetByIdAsync(id);
+            if (existing == null)
+                throw new InvalidOperationException("Subscription plan not found");
+
+            existing.PlanName = plan.PlanName;
+            existing.DurationDays = plan.DurationDays;
+            existing.MaxPerDay = plan.MaxPerDay;
+            existing.MaxPerMonth = plan.MaxPerMonth;
+            existing.Price = plan.Price;
+
+            await _repo.UpdateAsync(existing);
+        }
+
+        public async Task DeleteAsync(int id)
+        {
+            await _repo.DeleteAsync(id);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add strongly typed `JwtOptions` for key and issuer
- bind configuration and environment variables, failing fast if no signing key
- update auth service to use injected options

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689fe4e644048324936c94598fc42d42