### PR TITLE
Add subscription purchase workflow with payment handling

### DIFF
--- a/BookLibwithSub.API/Controllers/PaymentsController.cs
+++ b/BookLibwithSub.API/Controllers/PaymentsController.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using BookLibwithSub.Service.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BookLibwithSub.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class PaymentsController : ControllerBase
+    {
+        private readonly IPaymentService _paymentService;
+
+        public PaymentsController(IPaymentService paymentService)
+        {
+            _paymentService = paymentService;
+        }
+
+        public class WebhookRequest
+        {
+            public int TransactionId { get; set; }
+        }
+
+        [HttpPost("webhook")]
+        [AllowAnonymous]
+        public async Task<IActionResult> Webhook([FromBody] WebhookRequest request)
+        {
+            await _paymentService.MarkTransactionPaidAsync(request.TransactionId);
+            return Ok();
+        }
+    }
+}

--- a/BookLibwithSub.API/Controllers/SubscriptionsController.cs
+++ b/BookLibwithSub.API/Controllers/SubscriptionsController.cs
@@ -1,0 +1,54 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Threading.Tasks;
+using BookLibwithSub.Service.Constants;
+using BookLibwithSub.Service.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BookLibwithSub.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class SubscriptionsController : ControllerBase
+    {
+        private readonly ISubscriptionPlanService _planService;
+        private readonly ISubscriptionService _subscriptionService;
+
+        public SubscriptionsController(ISubscriptionPlanService planService, ISubscriptionService subscriptionService)
+        {
+            _planService = planService;
+            _subscriptionService = subscriptionService;
+        }
+
+        [HttpGet("plans")]
+        public async Task<IActionResult> GetPlans()
+        {
+            var plans = await _planService.GetAllAsync();
+            return Ok(plans);
+        }
+
+        public class PurchaseRequest
+        {
+            public int PlanId { get; set; }
+        }
+
+        [HttpPost("purchase")]
+        [Authorize(Roles = Roles.User)]
+        public async Task<IActionResult> Purchase([FromBody] PurchaseRequest request)
+        {
+            var userId = int.Parse(User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? "0");
+            var transaction = await _subscriptionService.PurchaseAsync(userId, request.PlanId);
+            return Ok(transaction);
+        }
+
+        [HttpPost("renew")]
+        [Authorize(Roles = Roles.User)]
+        public async Task<IActionResult> Renew()
+        {
+            var userId = int.Parse(User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? "0");
+            var transaction = await _subscriptionService.RenewAsync(userId);
+            return Ok(transaction);
+        }
+    }
+}

--- a/BookLibwithSub.API/Program.cs
+++ b/BookLibwithSub.API/Program.cs
@@ -24,6 +24,9 @@ builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<ISubscriptionPlanRepository, SubscriptionPlanRepository>();
 builder.Services.AddScoped<ISubscriptionPlanService, SubscriptionPlanService>();
 builder.Services.AddScoped<ISubscriptionRepository, SubscriptionRepository>();
+builder.Services.AddScoped<ITransactionRepository, TransactionRepository>();
+builder.Services.AddScoped<IPaymentService, PaymentService>();
+builder.Services.AddScoped<ISubscriptionService, SubscriptionService>();
 builder.Services.AddScoped<ILoanRepository, LoanRepository>();
 builder.Services.AddScoped<ILoanService, LoanService>();
 

--- a/BookLibwithSub.Repo/AppDbContext.cs
+++ b/BookLibwithSub.Repo/AppDbContext.cs
@@ -199,6 +199,10 @@ namespace BookLibwithSub.Repo
                 entity.Property(t => t.TransactionDate)
                     .HasColumnType("datetime2")
                     .HasDefaultValueSql("GETUTCDATE()");
+
+                entity.Property(t => t.Status)
+                    .IsRequired()
+                    .HasMaxLength(50);
             });
         }
     }

--- a/BookLibwithSub.Repo/Entities/Transaction.cs
+++ b/BookLibwithSub.Repo/Entities/Transaction.cs
@@ -16,6 +16,7 @@ namespace BookLibwithSub.Repo.Entities
         public decimal Amount { get; set; }
         public string TransactionType { get; set; }
         public DateTime TransactionDate { get; set; }
+        public string Status { get; set; }
 
         // Navigation
         public User User { get; set; }

--- a/BookLibwithSub.Repo/Interfaces/ISubscriptionPlanRepository.cs
+++ b/BookLibwithSub.Repo/Interfaces/ISubscriptionPlanRepository.cs
@@ -6,6 +6,7 @@ namespace BookLibwithSub.Repo.Interfaces
 {
     public interface ISubscriptionPlanRepository
     {
+        Task<List<SubscriptionPlan>> GetAllAsync();
         Task<SubscriptionPlan?> GetByIdAsync(int id);
         Task AddAsync(SubscriptionPlan plan);
         Task UpdateAsync(SubscriptionPlan plan);

--- a/BookLibwithSub.Repo/Interfaces/ISubscriptionRepository.cs
+++ b/BookLibwithSub.Repo/Interfaces/ISubscriptionRepository.cs
@@ -6,5 +6,9 @@ namespace BookLibwithSub.Repo.Interfaces
     public interface ISubscriptionRepository
     {
         Task<Subscription?> GetByIdWithPlanAsync(int id);
+        Task<Subscription?> GetActiveByUserAsync(int userId);
+        Task<Subscription?> GetLatestByUserAsync(int userId);
+        Task AddAsync(Subscription subscription);
+        Task UpdateAsync(Subscription subscription);
     }
 }

--- a/BookLibwithSub.Repo/Interfaces/ITransactionRepository.cs
+++ b/BookLibwithSub.Repo/Interfaces/ITransactionRepository.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+
+namespace BookLibwithSub.Repo.Interfaces
+{
+    public interface ITransactionRepository
+    {
+        Task AddAsync(Transaction transaction);
+        Task<Transaction?> GetByIdAsync(int id);
+        Task UpdateAsync(Transaction transaction);
+    }
+}

--- a/BookLibwithSub.Repo/Migrations/20250816030638_AddTransactionStatus.Designer.cs
+++ b/BookLibwithSub.Repo/Migrations/20250816030638_AddTransactionStatus.Designer.cs
@@ -4,6 +4,7 @@ using BookLibwithSub.Repo;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookLibwithSub.Repo.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250816030638_AddTransactionStatus")]
+    partial class AddTransactionStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookLibwithSub.Repo/Migrations/20250816030638_AddTransactionStatus.cs
+++ b/BookLibwithSub.Repo/Migrations/20250816030638_AddTransactionStatus.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookLibwithSub.Repo.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTransactionStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "Transactions",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Transactions");
+        }
+    }
+}

--- a/BookLibwithSub.Repo/SubscriptionPlanRepository.cs
+++ b/BookLibwithSub.Repo/SubscriptionPlanRepository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using BookLibwithSub.Repo.Entities;
 using BookLibwithSub.Repo.Interfaces;
@@ -11,6 +12,11 @@ namespace BookLibwithSub.Repo
         public SubscriptionPlanRepository(AppDbContext context)
         {
             _context = context;
+        }
+
+        public async Task<List<SubscriptionPlan>> GetAllAsync()
+        {
+            return await _context.SubscriptionPlans.ToListAsync();
         }
 
         public async Task<SubscriptionPlan?> GetByIdAsync(int id)

--- a/BookLibwithSub.Repo/SubscriptionRepository.cs
+++ b/BookLibwithSub.Repo/SubscriptionRepository.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using BookLibwithSub.Repo.Entities;
 using BookLibwithSub.Repo.Interfaces;
@@ -18,6 +20,35 @@ namespace BookLibwithSub.Repo
             return await _context.Subscriptions
                 .Include(s => s.SubscriptionPlan)
                 .FirstOrDefaultAsync(s => s.SubscriptionID == id);
+        }
+
+        public async Task<Subscription?> GetActiveByUserAsync(int userId)
+        {
+            var now = DateTime.UtcNow;
+            return await _context.Subscriptions
+                .Where(s => s.UserID == userId && s.Status == "Active" && s.StartDate <= now && s.EndDate > now)
+                .OrderByDescending(s => s.EndDate)
+                .FirstOrDefaultAsync();
+        }
+
+        public async Task<Subscription?> GetLatestByUserAsync(int userId)
+        {
+            return await _context.Subscriptions
+                .Where(s => s.UserID == userId)
+                .OrderByDescending(s => s.EndDate)
+                .FirstOrDefaultAsync();
+        }
+
+        public async Task AddAsync(Subscription subscription)
+        {
+            _context.Subscriptions.Add(subscription);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task UpdateAsync(Subscription subscription)
+        {
+            _context.Subscriptions.Update(subscription);
+            await _context.SaveChangesAsync();
         }
     }
 }

--- a/BookLibwithSub.Repo/TransactionRepository.cs
+++ b/BookLibwithSub.Repo/TransactionRepository.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+using BookLibwithSub.Repo.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookLibwithSub.Repo
+{
+    public class TransactionRepository : ITransactionRepository
+    {
+        private readonly AppDbContext _context;
+        public TransactionRepository(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task AddAsync(Transaction transaction)
+        {
+            _context.Transactions.Add(transaction);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task<Transaction?> GetByIdAsync(int id)
+        {
+            return await _context.Transactions.FirstOrDefaultAsync(t => t.TransactionID == id);
+        }
+
+        public async Task UpdateAsync(Transaction transaction)
+        {
+            _context.Transactions.Update(transaction);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/BookLibwithSub.Service/Interfaces/IPaymentService.cs
+++ b/BookLibwithSub.Service/Interfaces/IPaymentService.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+
+namespace BookLibwithSub.Service.Interfaces
+{
+    public interface IPaymentService
+    {
+        Task<Transaction> CreatePendingTransactionAsync(int userId, int subscriptionId, decimal amount);
+        Task MarkTransactionPaidAsync(int transactionId);
+    }
+}

--- a/BookLibwithSub.Service/Interfaces/ISubscriptionPlanService.cs
+++ b/BookLibwithSub.Service/Interfaces/ISubscriptionPlanService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using BookLibwithSub.Repo.Entities;
 
@@ -5,6 +6,7 @@ namespace BookLibwithSub.Service.Interfaces
 {
     public interface ISubscriptionPlanService
     {
+        Task<IEnumerable<SubscriptionPlan>> GetAllAsync();
         Task<SubscriptionPlan> AddAsync(SubscriptionPlan plan);
         Task<SubscriptionPlan?> GetByIdAsync(int id);
         Task UpdateAsync(int id, SubscriptionPlan plan);

--- a/BookLibwithSub.Service/Interfaces/ISubscriptionService.cs
+++ b/BookLibwithSub.Service/Interfaces/ISubscriptionService.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+
+namespace BookLibwithSub.Service.Interfaces
+{
+    public interface ISubscriptionService
+    {
+        Task<Transaction> PurchaseAsync(int userId, int planId);
+        Task<Transaction> RenewAsync(int userId);
+    }
+}

--- a/BookLibwithSub.Service/PaymentService.cs
+++ b/BookLibwithSub.Service/PaymentService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+using BookLibwithSub.Repo.Interfaces;
+using BookLibwithSub.Service.Interfaces;
+
+namespace BookLibwithSub.Service
+{
+    public class PaymentService : IPaymentService
+    {
+        private readonly ITransactionRepository _transactionRepo;
+        private readonly ISubscriptionRepository _subscriptionRepo;
+
+        public PaymentService(ITransactionRepository transactionRepo, ISubscriptionRepository subscriptionRepo)
+        {
+            _transactionRepo = transactionRepo;
+            _subscriptionRepo = subscriptionRepo;
+        }
+
+        public async Task<Transaction> CreatePendingTransactionAsync(int userId, int subscriptionId, decimal amount)
+        {
+            var transaction = new Transaction
+            {
+                UserID = userId,
+                SubscriptionID = subscriptionId,
+                Amount = amount,
+                TransactionType = "Subscription",
+                TransactionDate = DateTime.UtcNow,
+                Status = "Pending"
+            };
+
+            await _transactionRepo.AddAsync(transaction);
+            return transaction;
+        }
+
+        public async Task MarkTransactionPaidAsync(int transactionId)
+        {
+            var transaction = await _transactionRepo.GetByIdAsync(transactionId);
+            if (transaction == null) return;
+
+            transaction.Status = "Paid";
+            await _transactionRepo.UpdateAsync(transaction);
+
+            if (transaction.SubscriptionID.HasValue)
+            {
+                var subscription = await _subscriptionRepo.GetByIdWithPlanAsync(transaction.SubscriptionID.Value);
+                if (subscription != null)
+                {
+                    subscription.Status = "Active";
+                    await _subscriptionRepo.UpdateAsync(subscription);
+                }
+            }
+        }
+    }
+}

--- a/BookLibwithSub.Service/SubscriptionPlanService.cs
+++ b/BookLibwithSub.Service/SubscriptionPlanService.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using BookLibwithSub.Repo.Entities;
 using BookLibwithSub.Repo.Interfaces;
@@ -11,6 +13,11 @@ namespace BookLibwithSub.Service
         public SubscriptionPlanService(ISubscriptionPlanRepository repo)
         {
             _repo = repo;
+        }
+
+        public async Task<IEnumerable<SubscriptionPlan>> GetAllAsync()
+        {
+            return await _repo.GetAllAsync();
         }
 
         public async Task<SubscriptionPlan> AddAsync(SubscriptionPlan plan)

--- a/BookLibwithSub.Service/SubscriptionService.cs
+++ b/BookLibwithSub.Service/SubscriptionService.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading.Tasks;
+using BookLibwithSub.Repo.Entities;
+using BookLibwithSub.Repo.Interfaces;
+using BookLibwithSub.Service.Interfaces;
+
+namespace BookLibwithSub.Service
+{
+    public class SubscriptionService : ISubscriptionService
+    {
+        private readonly ISubscriptionRepository _subscriptionRepo;
+        private readonly ISubscriptionPlanRepository _planRepo;
+        private readonly IPaymentService _paymentService;
+
+        public SubscriptionService(ISubscriptionRepository subscriptionRepo,
+            ISubscriptionPlanRepository planRepo,
+            IPaymentService paymentService)
+        {
+            _subscriptionRepo = subscriptionRepo;
+            _planRepo = planRepo;
+            _paymentService = paymentService;
+        }
+
+        public async Task<Transaction> PurchaseAsync(int userId, int planId)
+        {
+            var active = await _subscriptionRepo.GetActiveByUserAsync(userId);
+            if (active != null)
+                throw new InvalidOperationException("User already has an active subscription");
+
+            var plan = await _planRepo.GetByIdAsync(planId);
+            if (plan == null)
+                throw new InvalidOperationException("Subscription plan not found");
+
+            var start = DateTime.UtcNow;
+            var subscription = new Subscription
+            {
+                UserID = userId,
+                SubscriptionPlanID = plan.SubscriptionPlanID,
+                StartDate = start,
+                EndDate = start.AddDays(plan.DurationDays),
+                Status = "Inactive"
+            };
+            await _subscriptionRepo.AddAsync(subscription);
+
+            return await _paymentService.CreatePendingTransactionAsync(userId, subscription.SubscriptionID, plan.Price);
+        }
+
+        public async Task<Transaction> RenewAsync(int userId)
+        {
+            var latest = await _subscriptionRepo.GetLatestByUserAsync(userId);
+            if (latest == null)
+                throw new InvalidOperationException("No subscription to renew");
+
+            var plan = await _planRepo.GetByIdAsync(latest.SubscriptionPlanID);
+            if (plan == null)
+                throw new InvalidOperationException("Subscription plan not found");
+
+            var start = latest.EndDate > DateTime.UtcNow ? latest.EndDate : DateTime.UtcNow;
+            var subscription = new Subscription
+            {
+                UserID = userId,
+                SubscriptionPlanID = plan.SubscriptionPlanID,
+                StartDate = start,
+                EndDate = start.AddDays(plan.DurationDays),
+                Status = "Inactive"
+            };
+            await _subscriptionRepo.AddAsync(subscription);
+
+            return await _paymentService.CreatePendingTransactionAsync(userId, subscription.SubscriptionID, plan.Price);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose subscription endpoints to list plans, purchase and renew
- add payment service and webhook to complete transactions and activate subscriptions
- extend data model with transaction status and supporting repositories

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_689ff477b1ac83249d4f817756e3444e