### PR TITLE
Configure local SQL Server for development

### DIFF
--- a/BookLibwithSub.API/appsettings.Development.json
+++ b/BookLibwithSub.API/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=BookLibDb;User Id=sa;Password=12345;TrustServerCertificate=True;"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- use local `sa`-authenticated connection for development
- keep production defaults untouched

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a46ed21c408324a55351983944bccf